### PR TITLE
Treat <esi:...> tags as CDATA sections instead of valid XML

### DIFF
--- a/src/Webfactory/Dom/BaseParsingHelper.php
+++ b/src/Webfactory/Dom/BaseParsingHelper.php
@@ -236,17 +236,14 @@ class BaseParsingHelper {
         return "<root {$this->xmlNamespaceDeclaration($declaredNamespaces)}>$fragment</root>";
     }
 
-    /*
-     * Wrapper-Methode, über die Subklassen den Rückgabewert von dump()
-     * nachverarbeiten können.
-     */
     protected function fixDump($dump)
     {
-        return $dump;
+        return preg_replace('_\<\!\[CDATA\[(<esi:[^>]+>)\]\]>_', '$1', $dump);
     }
 
     protected function sanitize($s)
     {
+        $s = preg_replace('_<esi:[^>]+>_', '<![CDATA[$0]]>', $s); // escape <esi:...> placeholders
         return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', ' ', $s);
     }
 }

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -13,7 +13,6 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
     protected $implicitNamespaces = array(
         ''     => 'http://www.w3.org/1999/xhtml', // default ns
         'html' => 'http://www.w3.org/1999/xhtml', // für XPath
-        'esi'  => 'http://www.edge-delivery.org/esi/1.0', // fuer ESI
         'hx'   => 'http://purl.org/NET/hinclude' // fuer HInclude http://mnot.github.io/hinclude/; ein Weg um z.B. Controller in Symfony per Ajax zu embedden
     );
 

--- a/src/Webfactory/Dom/PolyglotHTML5ParsingHelper.php
+++ b/src/Webfactory/Dom/PolyglotHTML5ParsingHelper.php
@@ -15,6 +15,8 @@ class PolyglotHTML5ParsingHelper extends HTMLParsingHelper {
     // HTML-Entities fixen als Bequemlichkeit für legacy (Case 12739)
     protected function sanitize($xml)
     {
+        $xml = parent::sanitize($xml);
+
         $escaped = str_replace(
             array('&amp;', '&lt;', '&gt;', '&quot;', '&apos;'),
             array('&amp;amp;', '&amp;lt;', '&amp;gt;', '&amp;quot;', '&amp;apos;'),
@@ -25,6 +27,8 @@ class PolyglotHTML5ParsingHelper extends HTMLParsingHelper {
 
     protected function fixDump($dump)
     {
+        $dump = parent::fixDump($dump);
+
         // http://www.w3.org/TR/html-polyglot/#empty-elements
         static $voidElements = array(
             'area',
@@ -40,8 +44,7 @@ class PolyglotHTML5ParsingHelper extends HTMLParsingHelper {
             'link',
             'meta',
             'param',
-            'source',
-            'esi'
+            'source'
         );
 
         preg_match_all('_<((?!\w+:)(\w+)[^>]*)/>_', $dump, $matches, PREG_SET_ORDER);

--- a/src/Webfactory/Dom/XHTML10ParsingHelper.php
+++ b/src/Webfactory/Dom/XHTML10ParsingHelper.php
@@ -20,21 +20,4 @@ class XHTML10ParsingHelper extends HTMLParsingHelper {
             );
     }
 
-    protected function fixDump($dump)
-    {
-        /*
-        * Vgl. http://mail.gnome.org/archives/xml/2011-December/msg00029.html
-        * Die libxml2 erkennt XHTML-Dokumente und gibt in diesem Fall nur die in der
-        * XHTML-DTD als EMPTY definierten Tags in <kurzer /> Form aus. Alle anderen
-        * Tags werden <so></so> ausgegeben, um mit http://www.w3.org/TR/xhtml1/#C_3
-        * konform zu gehen. Das LIBXML_EMPTYTAG-Flag in DOMDocument::saveXML spielt
-        * dabei keine Rolle.
-        *
-        * Mit anderen Worten: Wir können <esi:include .../> nicht in der notwendigen
-        * Form ausgeben, bis wir nicht mindestens eine gepatch'te Version der libxml2
-        * überall einsetzen können/wollen. Da ist das hier doch ein vertretbarer Fix,
-        * oder?
-        */
-        return str_replace('></esi:include>', '/>', $dump);
-    }
 }

--- a/test/Webfactory/Dom/Test/HTMLParsingHelperTest.php
+++ b/test/Webfactory/Dom/Test/HTMLParsingHelperTest.php
@@ -25,4 +25,9 @@ abstract class HTMLParsingHelperTest extends ParsingHelperTest {
     {
         $this->readDumpAssertFragment('<p>Test <esi:include foo="bar"/></p>');
     }
+
+    public function testEsiTagWithXMLSpecialCharsIsPreserved()
+    {
+        $this->readDumpAssertFragment('<p>Test <esi:include foo="http://foo.bar?one=two&three=four"/></p>');
+    }
 }


### PR DESCRIPTION
The ESI specs (http://www.w3.org/TR/esi-lang for examle) describe the ESI language as an "in-markup XML-based language".

Yet, it does not say anything about encoding the special XML characters. Most notably, this is the "&" ampersand that may show up in `esi:include` URLs.

The problem is that ESI tags may be embedded in all different kinds of content, for example plain text files. In these cases, you probably won't process the file with a full-fledged XML parser and thus not having the ampersands encoded is not going to be a problem.

As we also need to assume that the ESI implementation in surrogate caches is rather based on simple pattern/text replacement than complete XML processing, there's no guarantee that such implementations will be able to treat `&amp;` sequences found in URLs as "&" characters.

So, the safest option seems to be to place esi:... tags in `<![CDATA[...]]>` sections prior to XML processing and strip that markup again when dumping the DOM back to XML.
