### PR TITLE
Support character references for &, <, >, ' and "

### DIFF
--- a/src/Webfactory/Dom/PolyglotHTML5ParsingHelper.php
+++ b/src/Webfactory/Dom/PolyglotHTML5ParsingHelper.php
@@ -20,11 +20,14 @@ class PolyglotHTML5ParsingHelper extends HTMLParsingHelper {
         $xml = str_replace('xmlns="http://www.w3.org/2000/svg"', '_xmlns="http://www.w3.org/2000/svg"', $xml);
 
         $escaped = str_replace(
-            array('&amp;', '&lt;', '&gt;', '&quot;', '&apos;'),
-            array('&amp;amp;', '&amp;lt;', '&amp;gt;', '&amp;quot;', '&amp;apos;'),
+            ['&amp;', '&#38;', '&lt;', '&#60;', '&gt;', '&#62;', '&quot;', '&#34;', '&apos;', '&#39;'],
+            ['&amp;amp;', '&amp;amp;', '&amp;lt;', '&amp;lt;', '&amp;gt;', '&amp;gt;', '&amp;quot;', '&amp;quot;', '&amp;apos;', '&amp;apos;'],
             $xml
         );
-        return html_entity_decode($escaped, ENT_QUOTES, 'UTF-8');
+
+        $decoded = html_entity_decode($escaped, ENT_QUOTES, 'UTF-8');
+
+        return $decoded;
     }
 
     protected function fixDump($dump)


### PR DESCRIPTION
Polyglot HTML 5 markup (i. e. HTML 5 written in a way to be valid XML) only uses very few named entity references:

> Polyglot markup uses only the following named entity references:
> amp lt gt apos quot

https://www.w3.org/TR/html-polyglot/#named-entity-references

To support working with content that has been created before HTML5 – that is, XHTML1 – we substitute all named and character references with their plain values, which should not pose a problem in UTF-8 content. Only `&amp;`, `&lt;`, `&gt;`, `&quot;` and `&apos;` shall be kept.

We missed, however, that e. g. `&amp;` can also be written as `&#38;`; similar for the other characters. This PR adds support for these cases as well.

