### PR TITLE
Ändere Reihenfolge der XML-Namespaces im HTMLParsingHelper ab PHP 8.1.21 (Case 161357)

### DIFF
--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -58,7 +58,7 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
          * - https://github.com/php/php-src/commit/b30be40b86b62fc681c432fd96840d8e57e172a5 (https://bugs.php.net/bug.php?id=55294)
          *
          * but it perfectly matches our observation that changing the namespace order fixes several bugs and tests
-         * in various private projects.
+         * in various private projects of ours.
          */
         if (phpversion('xml') >= '8.1.21') {
             return [

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -44,7 +44,7 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
 
     protected function defineImplicitNamespaces(): array
     {
-        if(phpversion('xml') >= '8.1.21') {
+        if (phpversion('xml') >= '8.1.21') {
             return [
                 'html' => 'http://www.w3.org/1999/xhtml', // für XPath
                 ''     => 'http://www.w3.org/1999/xhtml', // default ns

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -48,8 +48,8 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
          * The Update to PHP 8.1.21 apparently changes the search order for defined namespaces during the process
          * of reconciliation, resulting in finding the namespace having the prefix 'html' prior to the default one
          * without prefix, as the search seems to start from the last defined prefix now. This results in DOMElements
-         * getting a wrong prefix while being appended to another element using `appendChild()`,
-         * e.g in `BaseParsingHelper::dump()`.
+         * getting a wrong prefix while being appended to another element using `appendChild()` e.g. in
+         * `BaseParsingHelper::dump()`.
          *
          * This is definitely a supposition, as we do not get everything completely what happens in the correspondig
          * commits

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -44,6 +44,22 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
 
     protected function defineImplicitNamespaces(): array
     {
+        /**
+         * The Update to PHP 8.1.21 apparently changed the search order for defined namespaces during the process
+         * of reconciliation, resulting in finding the namespace having the prefix 'html' prior to the default one
+         * without prefix, as the search seems to start from the last defined prefix now. This results in DOMElements
+         * getting a wrong prefix while being appended to another element using `appendChild()`,
+         * e.g in `BaseParsingHelper::dump()`.
+         *
+         * This is definitely a supposition, as we do not get everything completely what happens in the correspondig
+         * commits
+         *
+         * - https://github.com/php/php-src/commit/b1d8e240e688cae810c83b364772bf140ac45f42 (https://bugs.php.net/bug.php?id=67440)
+         * - https://github.com/php/php-src/commit/b30be40b86b62fc681c432fd96840d8e57e172a5 (https://bugs.php.net/bug.php?id=55294)
+         *
+         * but it perfectly matches our observation that changing the namespace order fixes several bugs and tests
+         * in various private projects.
+         */
         if (phpversion('xml') >= '8.1.21') {
             return [
                 'html' => 'http://www.w3.org/1999/xhtml', // für XPath

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -10,14 +10,12 @@ namespace Webfactory\Dom;
 
 abstract class HTMLParsingHelper extends BaseParsingHelper {
 
-    protected $implicitNamespaces = array(
-        'html' => 'http://www.w3.org/1999/xhtml', // für XPath
-        ''     => 'http://www.w3.org/1999/xhtml', // default ns
-        'hx'   => 'http://purl.org/NET/hinclude' // fuer HInclude http://mnot.github.io/hinclude/; ein Weg um z.B. Controller in Symfony per Ajax zu embedden
-    );
+    protected $implicitNamespaces;
 
     public function __construct()
     {
+        $this->implicitNamespaces = $this->defineImplicitNamespaces();
+
         libxml_set_external_entity_loader(function ($public, $system, $context) {
             if (isset($public)) {
                 $catalogDir = __DIR__ . '/../../../xml-catalog/';
@@ -42,5 +40,22 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
     protected function wrapFragment($fragment, $declaredNamespaces)
     {
         return "<html {$this->xmlNamespaceDeclaration($declaredNamespaces)}>$fragment</html>";
+    }
+
+    protected function defineImplicitNamespaces(): array
+    {
+        if(phpversion('xml') >= '8.1.21') {
+            return [
+                'html' => 'http://www.w3.org/1999/xhtml', // für XPath
+                ''     => 'http://www.w3.org/1999/xhtml', // default ns
+                'hx'   => 'http://purl.org/NET/hinclude' // fuer HInclude http://mnot.github.io/hinclude/; ein Weg um z.B. Controller in Symfony per Ajax zu embedden
+            ];
+        }
+
+        return [
+            ''     => 'http://www.w3.org/1999/xhtml', // default ns
+            'html' => 'http://www.w3.org/1999/xhtml', // für XPath
+            'hx'   => 'http://purl.org/NET/hinclude' // fuer HInclude http://mnot.github.io/hinclude/; ein Weg um z.B. Controller in Symfony per Ajax zu embedden
+        ];
     }
 }

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -51,7 +51,7 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
          * getting a wrong prefix while being appended to another element using `appendChild()` e.g. in
          * `BaseParsingHelper::dump()`.
          *
-         * This is definitely a supposition, as we do not get everything completely what happens in the correspondig
+         * This is definitely a supposition, as we do not get everything completely what happens in the corresponding
          * commits
          *
          * - https://github.com/php/php-src/commit/b1d8e240e688cae810c83b364772bf140ac45f42 (https://bugs.php.net/bug.php?id=67440)

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -45,7 +45,7 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
     protected function defineImplicitNamespaces(): array
     {
         /**
-         * The Update to PHP 8.1.21 apparently changed the search order for defined namespaces during the process
+         * The Update to PHP 8.1.21 apparently changes the search order for defined namespaces during the process
          * of reconciliation, resulting in finding the namespace having the prefix 'html' prior to the default one
          * without prefix, as the search seems to start from the last defined prefix now. This results in DOMElements
          * getting a wrong prefix while being appended to another element using `appendChild()`,

--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -11,8 +11,8 @@ namespace Webfactory\Dom;
 abstract class HTMLParsingHelper extends BaseParsingHelper {
 
     protected $implicitNamespaces = array(
-        ''     => 'http://www.w3.org/1999/xhtml', // default ns
         'html' => 'http://www.w3.org/1999/xhtml', // für XPath
+        ''     => 'http://www.w3.org/1999/xhtml', // default ns
         'hx'   => 'http://purl.org/NET/hinclude' // fuer HInclude http://mnot.github.io/hinclude/; ein Weg um z.B. Controller in Symfony per Ajax zu embedden
     );
 


### PR DESCRIPTION
Wir haben in unseren Vagrants bereits das Update von PHP 8.1.20 auf 8.1.21 bekommen, und auf dem CI ist es auch schon vorhanden. Das Updates hat [Tests rot](https://github.com/webfactory/gemeinsamer-bundesausschuss/actions/runs/5504954377/jobs/10031727007) [werden lassen](https://github.com/webfactory/staatstheater-darmstadt/actions/runs/5505340414/jobs/10032573906) und auch lokal Webseiten zerpflückt.

Über (diverse? alle?) TagRewriter wird früher oder später die Methode `BaseParsingHelper::dump()` aufgerufen, in der das vom TagRewriter behandelte `DOMElement` an ein [vorher gebautes](https://github.com/webfactory/dom/blob/296711b867214753c3da206135dd248ae85b2a82/src/Webfactory/Dom/BaseParsingHelper.php#L168) Elternelement aus einem `DOMDocument` [angehängt wird](https://github.com/webfactory/dom/blob/296711b867214753c3da206135dd248ae85b2a82/src/Webfactory/Dom/BaseParsingHelper.php#L177). Das Elternelement wird gebaut, indem ein leeres Fragment gewrappt wird, wobei [implizite Namespaces](https://github.com/webfactory/dom/blob/296711b867214753c3da206135dd248ae85b2a82/src/Webfactory/Dom/HTMLParsingHelper.php#L13) mitgegeben werden.

Mit dem PHP-Update erhielten vom TagRewriter behandelte Elemente auf einmal den Prefix `html`, bspw. `<html:a>...</a>`. Wir haben uns die in Frage kommenden Bugfixes aus dem [Changelog von PHP 8.1.21](https://www.php.net/ChangeLog-8.php#PHP_8_1) und die dazugehörigen Commits angeschaut:

- https://github.com/php/php-src/commit/b1d8e240e688cae810c83b364772bf140ac45f42 (https://bugs.php.net/bug.php?id=67440)
- https://github.com/php/php-src/commit/b30be40b86b62fc681c432fd96840d8e57e172a5 (https://bugs.php.net/bug.php?id=55294)

Sebastian ist dabei die Methode `xmlSearchNsByHref` ("Ns" heißt vermutlich "Namespace") ins Auge gefallen, und wir haben daraus gefolgert, dass an mehreren Stellen ein Namespace anhand seiner URL identifizert wird. Wir haben [im HTML5ParsingHelper](https://github.com/webfactory/dom/blob/296711b867214753c3da206135dd248ae85b2a82/src/Webfactory/Dom/HTMLParsingHelper.php#L13) aber denselben Namespace einmal als default (ohne Prefix), und einmal mit dem Prefix `html` definiert. Diese Methode ist in der Libxml2 implementiert.

Daraufhin hat Martin vermutet, dass einer von den beiden Commits in PHP zur Folge hat, dass der Namespace des anzuhängenden Elements dazu führt, dass für den Namespace `http://www.w3.org/1999/xhtml`, den (vermutlich?) auch das anzuhängende Element hat, nicht mehr der der Default-Namespace, sondern der mit dem dem Prefix `html` gefunden wird, was zur Folge hat, dass der Prefix beim `appendChild()` auch davorgeschrieben wird, weil er vom default abweicht. Vermutlich werden also mit der neuen PHP-Version die im Root-Element deklarierten Namespaces in der umgekehrten Reihenfolge durchsucht.

All das ist letztendlich Hypothese, weil wir die beiden Commits in PHP nicht vollständig durchdringen, es deckt sich aber mit unseren Beobachtungen, dass ein Vertauschen der beiden Prefixes für den Namespace die Webseiten des GBA und STD wieder in Ordnung bringt und auch die Tests wieder Grün werden lässt.

Es stellt sich nur die Frage, warum wir denselben Namespace zweimal definieren. Einmal als default ohne Prefix, und einmal "für XPath" mit dem Prefix `html`. Warum benutzen wird für XPath nicht auch den default-Prefix?

Nach unserem Verständnis sind Namespaces durch die URI definiert und das Präfix ist nur eine Abkürzung/Vereinfachung und hat ansonsten keine Semantik:

> Note that the prefix functions only as a placeholder for a namespace name. Applications SHOULD use the namespace name, not the prefix, in constructing names whose scope extends beyond the containing document. (https://www.w3.org/TR/xml-names/#ns-qualnames)

Damit sind sind zwei Namespaces mit identischen URLs als identisch anzusehen, auch wenn sie unterschiedliche Präfixes haben. Es ist also als XML-Sicht eigentlich äquivalent, ob das `html:`-Präfix vorangestellt wird oder nicht; nur die Browser sehen das anders. Die Änderung der Suchreihenfolge ist also nicht unbedingt ein Bug.

<img width="2032" alt="Screenshot 2023-07-12 at 08 34 27" src="https://github.com/webfactory/dom/assets/8628559/63e7196e-a010-4fdc-83ac-f933d4887e51">
