### PR TITLE
Use old namespace reconciliation behaviour in PHP > 8.1.24

### DIFF
--- a/src/Webfactory/Dom/HTMLParsingHelper.php
+++ b/src/Webfactory/Dom/HTMLParsingHelper.php
@@ -60,7 +60,7 @@ abstract class HTMLParsingHelper extends BaseParsingHelper {
          * but it perfectly matches our observation that changing the namespace order fixes several bugs and tests
          * in various private projects of ours.
          */
-        if (phpversion('xml') >= '8.1.21') {
+        if ((phpversion('xml') >= '8.1.21') && (phpversion('xml') < '8.1.25')){
             return [
                 'html' => 'http://www.w3.org/1999/xhtml', // für XPath
                 ''     => 'http://www.w3.org/1999/xhtml', // default ns


### PR DESCRIPTION
In PHP 8.1.25, the old namespace reconciliation behaviour was restored, see https://www.php.net/ChangeLog-8.php#PHP_8_1. Thus, we have to limit our workaround to versions between 8.1.21 and 8.1.24.